### PR TITLE
SDK 2.5.1: Add public_key_pem field to properties

### DIFF
--- a/saltedge-compliance-connector-java-v2/SDK_CHANGELOG.MD
+++ b/saltedge-compliance-connector-java-v2/SDK_CHANGELOG.MD
@@ -1,5 +1,13 @@
 # Salt Edge Compliance Connector SDK Changelog
 
+## 2.5.1 (2021-01-06)  
+### Add:  
+- Add `public_key_pem` field to properties
+
+### Change:
+- Refactor ResourceTools
+- Replace printStackTrace with logger
+
 ## 2.5.0 (2020-12-01)
 Add support for the FPS (Faster Payment Service)  
 

--- a/saltedge-compliance-connector-java-v2/compliance-connector-sdk/ExampleProviderService.java
+++ b/saltedge-compliance-connector-java-v2/compliance-connector-sdk/ExampleProviderService.java
@@ -137,7 +137,7 @@ public class ExampleProviderService implements ProviderServiceAbs {
             Arrays.stream(params).forEach(item -> builder.queryParam("session_secret", sessionSecret));
             return builder.build().toUriString();
         } catch (Exception e) {
-            e.printStackTrace();
+            log.error(e.getMessage(), e);
             return null;
         }
     }
@@ -355,7 +355,7 @@ public class ExampleProviderService implements ProviderServiceAbs {
             Arrays.stream(params).forEach(item -> builder.queryParam("payment_id", paymentId));
             return builder.build().toUriString();
         } catch (Exception e) {
-            e.printStackTrace();
+            log.error(e.getMessage(), e);
             return null;
         }
     }

--- a/saltedge-compliance-connector-java-v2/compliance-connector-sdk/README.MD
+++ b/saltedge-compliance-connector-java-v2/compliance-connector-sdk/README.MD
@@ -119,9 +119,11 @@ connector:
     app_secret: ZZZZZZZZZZ
     base_url: https://priora.saltedge.com/
     public_key_name: priora_public_prod.pem
+    public_key_pem: -----BEGIN PUBLIC KEY-----\nXXXXX\n-----END PUBLIC KEY-----
 ```   
 
-Set `private_key_name` or `private_key_pem`.  
+Set one of the field for the private key (`private_key_name` or `private_key_pem`).
+Set one of the field for the public key (`public_key_name` or `public_key_pem`).
   
   
 ## [Api Documentation](https://priora.banksalt.com/docs/aspsp/v2)

--- a/saltedge-compliance-connector-java-v2/compliance-connector-sdk/build.gradle
+++ b/saltedge-compliance-connector-java-v2/compliance-connector-sdk/build.gradle
@@ -8,7 +8,7 @@ plugins {
 }
 
 group 'com.saltedge.connector.sdk'
-version '2.5.0'
+version '2.5.1'
 
 compileJava {
     sourceCompatibility = 1.8

--- a/saltedge-compliance-connector-java-v2/compliance-connector-sdk/src/main/java/com/saltedge/connector/sdk/api/interceptors/PrioraRequestResolver.java
+++ b/saltedge-compliance-connector-java-v2/compliance-connector-sdk/src/main/java/com/saltedge/connector/sdk/api/interceptors/PrioraRequestResolver.java
@@ -28,6 +28,8 @@ import com.saltedge.connector.sdk.api.models.requests.*;
 import com.saltedge.connector.sdk.config.ApplicationProperties;
 import com.saltedge.connector.sdk.tools.JsonTools;
 import io.jsonwebtoken.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.MethodParameter;
 import org.springframework.stereotype.Component;
@@ -43,6 +45,7 @@ import java.util.Map;
  */
 @Component
 public class PrioraRequestResolver implements HandlerMethodArgumentResolver {
+    private static final Logger log = LoggerFactory.getLogger(PrioraRequestResolver.class);
     @Autowired
     ApplicationProperties applicationProperties;
     private final ObjectMapper mapper = JsonTools.createDefaultMapper();
@@ -84,7 +87,7 @@ public class PrioraRequestResolver implements HandlerMethodArgumentResolver {
         } catch (JwtException e) {
             throw new BadRequest.JWTDecodeError(e.getMessage());
         } catch (Exception e) {
-            e.printStackTrace();
+            log.error(e.getMessage(), e);
             throw new BadRequest.WrongRequestFormat(e.getMessage());
         }
     }

--- a/saltedge-compliance-connector-java-v2/compliance-connector-sdk/src/main/java/com/saltedge/connector/sdk/api/models/err/ApiExceptionsHandler.java
+++ b/saltedge-compliance-connector-java-v2/compliance-connector-sdk/src/main/java/com/saltedge/connector/sdk/api/models/err/ApiExceptionsHandler.java
@@ -38,7 +38,7 @@ import javax.validation.ConstraintViolationException;
  */
 @ControllerAdvice
 public class ApiExceptionsHandler extends ResponseEntityExceptionHandler {
-    private static Logger log = LoggerFactory.getLogger(ApiExceptionsHandler.class);
+    private static final Logger log = LoggerFactory.getLogger(ApiExceptionsHandler.class);
 
     @ExceptionHandler({
             BadRequest.class,
@@ -46,18 +46,15 @@ public class ApiExceptionsHandler extends ResponseEntityExceptionHandler {
             Unauthorized.class
     })
     public ResponseEntity<ErrorResponse> handleCustomException(Exception ex, WebRequest request) {
-        System.out.println("ApiExceptionsHandler:handleCustomException:" + ex.getLocalizedMessage());
         HttpStatus errorStatus = ex instanceof HttpErrorParams ? ((HttpErrorParams) ex).getErrorStatus() : HttpStatus.BAD_REQUEST;
         ErrorResponse error = new ErrorResponse(ex);
         log.error(error.toString());
-        ex.printStackTrace();
         return ResponseEntity.status(errorStatus).body(error);
     }
 
     @ExceptionHandler(ConstraintViolationException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     ResponseEntity<ErrorResponse> handleConstraintViolationException(ConstraintViolationException ex) {
-        System.out.println("ApiExceptionsHandler:handleConstraintViolationException:" + ex.getLocalizedMessage());
         ErrorResponse error = new ErrorResponse("WrongRequestFormat", ex.getMessage());
         log.error(ex.toString());
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(error);

--- a/saltedge-compliance-connector-java-v2/compliance-connector-sdk/src/main/java/com/saltedge/connector/sdk/callback/CallbackRestClient.java
+++ b/saltedge-compliance-connector-java-v2/compliance-connector-sdk/src/main/java/com/saltedge/connector/sdk/callback/CallbackRestClient.java
@@ -63,7 +63,7 @@ public abstract class CallbackRestClient {
             URL baseUrl = priora.getPrioraBaseUrl();
             return new URL(baseUrl, path).toString();
         } catch (MalformedURLException e) {
-            e.printStackTrace();
+            getLogger().error(e.getMessage(), e);
         }
         return null;
     }
@@ -92,13 +92,10 @@ public abstract class CallbackRestClient {
             headers.add("X-HTTP-Method-Override", "PATCH");
             ResponseEntity<Object> response = callbackRestTemplate.exchange(url, HttpMethod.POST, new HttpEntity<>(headers), Object.class);
         } catch (HttpClientErrorException e) {
-            e.printStackTrace();
             getLogger().error("HttpClientErrorException:", e);
         } catch (HttpServerErrorException e) {
-            e.printStackTrace();
             getLogger().error("HttpServerErrorException:", e);
         } catch (UnknownHttpStatusCodeException e) {
-            e.printStackTrace();
             getLogger().error("UnknownHttpStatusCodeException:", e);
         }
     }
@@ -112,7 +109,7 @@ public abstract class CallbackRestClient {
                     + "\n"
             );
         } catch (Exception e) {
-            e.printStackTrace();
+            getLogger().error(e.getMessage(), e);
         }
     }
 

--- a/saltedge-compliance-connector-java-v2/compliance-connector-sdk/src/main/java/com/saltedge/connector/sdk/config/PrioraProperties.java
+++ b/saltedge-compliance-connector-java-v2/compliance-connector-sdk/src/main/java/com/saltedge/connector/sdk/config/PrioraProperties.java
@@ -22,6 +22,8 @@ package com.saltedge.connector.sdk.config;
 
 import com.saltedge.connector.sdk.tools.KeyTools;
 import com.saltedge.connector.sdk.tools.ResourceTools;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Configuration;
 
 import javax.validation.constraints.NotBlank;
@@ -44,6 +46,7 @@ import java.security.PublicKey;
  */
 @Configuration
 public class PrioraProperties {
+    private static final Logger log = LoggerFactory.getLogger(PrioraProperties.class);
     /**
      * Registered Connector code
      * (https://priora.saltedge.com/providers/settings#details)
@@ -76,8 +79,12 @@ public class PrioraProperties {
      * Name of Salt Edge Compliance public key file in PEM format.
      * By default: `priora_public_prod.pem`
      */
-    @NotBlank
     private String publicKeyName = "priora_public_prod.pem";
+
+    /**
+     * Name of Salt Edge Compliance public key string in PEM format.
+     */
+    private String publicKeyPem;
 
     private PublicKey publicKey;
 
@@ -85,14 +92,18 @@ public class PrioraProperties {
         try {
             return new URL(baseUrl);
         } catch (MalformedURLException e) {
-            e.printStackTrace();
+            log.error(e.getMessage(), e);
         }
         return null;
     }
 
     public PublicKey getPrioraPublicKey() {
         if (publicKey == null) {
-            publicKey = KeyTools.convertPemStringToPublicKey(ResourceTools.readKeyFile(publicKeyName));
+            if (publicKeyName != null && !publicKeyName.trim().isEmpty()) {
+                publicKey = KeyTools.convertPemStringToPublicKey(ResourceTools.readKeyFile(publicKeyName));
+            } else if (publicKeyPem != null && !publicKeyPem.trim().isEmpty()) {
+                publicKey = KeyTools.convertPemStringToPublicKey(publicKeyPem);
+            }
         }
         return publicKey;
     }

--- a/saltedge-compliance-connector-java-v2/compliance-connector-sdk/src/main/java/com/saltedge/connector/sdk/tools/CodeBuilder.java
+++ b/saltedge-compliance-connector-java-v2/compliance-connector-sdk/src/main/java/com/saltedge/connector/sdk/tools/CodeBuilder.java
@@ -20,6 +20,9 @@
  */
 package com.saltedge.connector.sdk.tools;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -28,6 +31,7 @@ import java.util.Random;
 
 public class CodeBuilder {
     public static final String DEFAULT_SALT = CodeBuilder.generateRandomString(16);
+    private static final Logger log = LoggerFactory.getLogger(CodeBuilder.class);
 
     public static String generateRandomString() {
         return generateRandomString(32);
@@ -52,7 +56,7 @@ public class CodeBuilder {
         try {
             hashBytes = MessageDigest.getInstance("SHA-256").digest(hashBytes);
         } catch (NoSuchAlgorithmException e) {
-            e.printStackTrace();
+            log.error(e.getMessage(), e);
         }
         return Base64.getEncoder().withoutPadding().encodeToString(hashBytes);
     }
@@ -63,7 +67,7 @@ public class CodeBuilder {
         try {
             hashBytes = MessageDigest.getInstance("SHA-256").digest(hashBytes);
         } catch (NoSuchAlgorithmException e) {
-            e.printStackTrace();
+            log.error(e.getMessage(), e);
         }
         return Base64.getEncoder().encodeToString(hashBytes);
     }

--- a/saltedge-compliance-connector-java-v2/compliance-connector-sdk/src/main/java/com/saltedge/connector/sdk/tools/KeyTools.java
+++ b/saltedge-compliance-connector-java-v2/compliance-connector-sdk/src/main/java/com/saltedge/connector/sdk/tools/KeyTools.java
@@ -20,6 +20,10 @@
  */
 package com.saltedge.connector.sdk.tools;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.validation.constraints.NotNull;
 import java.security.KeyFactory;
 import java.security.PrivateKey;
 import java.security.PublicKey;
@@ -29,6 +33,8 @@ import java.security.spec.X509EncodedKeySpec;
 import java.util.Base64;
 
 public class KeyTools {
+    private static final Logger log = LoggerFactory.getLogger(KeyTools.class);
+
     /**
      * Generates random base64 encoded string with desired length
      *
@@ -58,7 +64,7 @@ public class KeyTools {
             X509EncodedKeySpec keySpecX509 = new X509EncodedKeySpec(Base64.getMimeDecoder().decode(keyContent));
             return kf.generatePublic(keySpecX509);
         } catch (Exception e) {
-            e.printStackTrace();
+            log.error(e.getMessage(), e);
             return null;
         }
     }
@@ -69,7 +75,7 @@ public class KeyTools {
      * @param pemString private key in PEM format
      * @return PrivateKey or null
      */
-    public static PrivateKey convertPemStringToPrivateKey(String pemString) {
+    public static PrivateKey convertPemStringToPrivateKey(@NotNull String pemString) {
         try {
             String keyContent = pemString.replace("\\n", "")
                     .replace("-----BEGIN PRIVATE KEY-----", "")
@@ -77,7 +83,7 @@ public class KeyTools {
             PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(Base64.getMimeDecoder().decode(keyContent));
             return KeyFactory.getInstance("RSA").generatePrivate(keySpec);
         } catch (Exception e) {
-            e.printStackTrace();
+            log.error(e.getMessage(), e);
             return null;
         }
     }

--- a/saltedge-compliance-connector-java-v2/compliance-connector-sdk/src/main/java/com/saltedge/connector/sdk/tools/ResourceTools.java
+++ b/saltedge-compliance-connector-java-v2/compliance-connector-sdk/src/main/java/com/saltedge/connector/sdk/tools/ResourceTools.java
@@ -20,12 +20,20 @@
  */
 package com.saltedge.connector.sdk.tools;
 
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.net.URL;
-import java.util.Scanner;
+import com.saltedge.connector.sdk.config.PrioraProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 
 public class ResourceTools {
+    private static final Logger log = LoggerFactory.getLogger(ResourceTools.class);
+
     /**
      * Reads key file from `resources`
      *
@@ -33,20 +41,21 @@ public class ResourceTools {
      * @return key file content or null
      */
     public static String readKeyFile(String filename) {
-        if (filename == null) return null;
-        StringBuilder result = new StringBuilder("");
-
-        URL resURL = ResourceTools.class.getClassLoader().getResource(filename);
-        if (resURL == null) return result.toString();
-        File file = new File(resURL.getFile());
-
-        try (Scanner scanner = new Scanner(file)) {
-            while (scanner.hasNextLine()) {
-                result.append(scanner.nextLine()).append("\n");
-            }
-        } catch (FileNotFoundException e) {
-            e.printStackTrace();
+        Resource fileResource = new ClassPathResource(filename);
+        try {
+            return readFromInputStream(fileResource.getInputStream());
+        } catch (IOException e) {
+            log.error(e.getMessage(), e);
+            return "";
         }
-        return result.toString();
+    }
+
+    private static String readFromInputStream(InputStream inputStream) throws IOException {
+        StringBuilder resultStringBuilder = new StringBuilder();
+        try (BufferedReader br = new BufferedReader(new InputStreamReader(inputStream))) {
+            String line;
+            while ((line = br.readLine()) != null) resultStringBuilder.append(line).append("\n");
+        }
+        return resultStringBuilder.toString();
     }
 }

--- a/saltedge-compliance-connector-java-v2/compliance-connector-sdk/src/test/java/com/saltedge/connector/sdk/TestTools.java
+++ b/saltedge-compliance-connector-java-v2/compliance-connector-sdk/src/test/java/com/saltedge/connector/sdk/TestTools.java
@@ -20,12 +20,15 @@
  */
 package com.saltedge.connector.sdk;
 
+import com.saltedge.connector.sdk.api.models.err.ApiExceptionsHandler;
 import com.saltedge.connector.sdk.provider.ProviderServiceAbs;
 import com.saltedge.connector.sdk.tools.JsonTools;
 import com.saltedge.connector.sdk.tools.KeyTools;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.jackson.io.JacksonSerializer;
 import org.assertj.core.util.Lists;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.FileNotFoundException;

--- a/saltedge-compliance-connector-java-v2/compliance-connector-sdk/src/test/java/com/saltedge/connector/sdk/tools/ResourceToolsTest.java
+++ b/saltedge-compliance-connector-java-v2/compliance-connector-sdk/src/test/java/com/saltedge/connector/sdk/tools/ResourceToolsTest.java
@@ -29,6 +29,6 @@ public class ResourceToolsTest {
 	public void readKeyFileTest() {
 		assertThat(new ResourceTools()).isNotNull();
 		assertThat(ResourceTools.readKeyFile("param-param.pem")).isEmpty();
-		assertThat(ResourceTools.readKeyFile("test_public_key.pem")).isNotEmpty();
+		assertThat(ResourceTools.readKeyFile("test_public_key.pem")).startsWith("-----BEGIN PUBLIC KEY-----");
 	}
 }

--- a/saltedge-compliance-connector-java-v2/example/src/main/java/com/saltedge/connector/example/compliance_connector/ProviderService.java
+++ b/saltedge-compliance-connector-java-v2/example/src/main/java/com/saltedge/connector/example/compliance_connector/ProviderService.java
@@ -86,7 +86,7 @@ public class ProviderService implements ProviderServiceAbs {
         new AbstractMap.SimpleImmutableEntry<>(SDKConstants.KEY_SESSION_SECRET, sessionSecret)
       );
     } catch (Exception e) {
-      e.printStackTrace();
+      log.error(e.getMessage(), e);
       return null;
     }
   }
@@ -269,7 +269,7 @@ public class ProviderService implements ProviderServiceAbs {
         new AbstractMap.SimpleImmutableEntry<>(SDKConstants.KEY_PAYMENT_ID, paymentId)
       );
     } catch (Exception e) {
-      e.printStackTrace();
+      log.error(e.getMessage(), e);
       return null;
     }
   }


### PR DESCRIPTION
https://github.com/saltedge/compliance-examples/issues/33  
- Allow to configure the public key as a string (in a similar way as for private key). this will make easier for to handle the values in spring cloud config.
- Replace this getResource with something more spring related like using a ResourceLoader
- Avoid using those e.printStackTrace() and use a logger to log the exception instead